### PR TITLE
Fix bandwidth status update

### DIFF
--- a/setup/dashboard/inc/config.php
+++ b/setup/dashboard/inc/config.php
@@ -70,22 +70,26 @@ function formatsize($size) {
 
 //NIC flow
 $strs = @file("/proc/net/dev");
-for ($i = 2; $i < count($strs); $i++ ) {
-  preg_match_all("/([^\s]+):[\s]{0,}(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/", $strs[$i], $info );
-  $NetInputSpeed[$i] = $info[2][0]; // Receive data in bytes
-  $NetOutSpeed[$i] = $info[10][0]; // Transmit data in bytes
+// only index start from 0 will be encoded as an array
+$NetInputSpeed = [0 => NULL, 1 => NULL];
+$NetOutSpeed = [0 => NULL, 1 => NULL];
+
+for ($i = 2; $i < count($strs); $i++) {
+  preg_match_all("/(?<name>[^\s]+):[\s]{0,}(?<rx_bytes>\d+)\s+(?:\d+\s+){7}(?<tx_bytes>\d+)\s+/", $strs[$i], $info);
+  $NetInputSpeed[$i] = $info["rx_bytes"][0]; // Receive data in bytes
+  $NetOutSpeed[$i] = $info["tx_bytes"][0]; // Transmit data in bytes
 }
 
 //Real-time refresh ajax calls
 if ($_GET["act"] == "rt") {
-  $arr=array(
+  $arr = array(
     "NetOutSpeed" => $NetOutSpeed,
     "NetInputSpeed" => $NetInputSpeed,
-    "NetTimeStamp" => microtime(true)
+    "NetTimeStamp" => microtime(true),
+    "InterfaceIndex" => count($strs)
   );
-  $jarr=json_encode($arr);
-  $_GET["callback"] = htmlspecialchars($_GET["callback"]);
-  echo $_GET["callback"],"(",$jarr,")";
+  $jarr = json_encode($arr);
+  echo htmlspecialchars($_GET["callback"])."(".$jarr.")";
   exit;
 }
 

--- a/setup/dashboard/inc/panel.app_status.ajax.js
+++ b/setup/dashboard/inc/panel.app_status.ajax.js
@@ -100,7 +100,7 @@
     name: "NETWORK",
     url: "/?act=rt&callback=?",
     id: undefined,
-    overload: function (task) {
+    override: function (task) {
       function format(length, factor, tail, fractionDigits) {
         return (length / Math.pow(2, factor)).toFixed(fractionDigits).toString() + tail;
       }
@@ -121,7 +121,7 @@
 
       $.getJSON(task.url, function (dataJSON) {
         const duration = (dataJSON.NetTimeStamp - window.NetTimeStamp);
-        for (let i = 2; i < 5; ++i) {
+        for (let i = 2; i <= dataJSON.InterfaceIndex; ++i) {
           if (window.NetOutSpeed[i] !== undefined) {
             const speed = (dataJSON.NetOutSpeed[i] - window.NetOutSpeed[i]) / duration;
             const speed_str = formatsize(speed);
@@ -209,8 +209,8 @@
           // set a delay for each task.
           setTimeout(function() {
             if (task.before) task.before(task);
-            if (task.overload) {
-              task.overload(task);
+            if (task.override) {
+              task.override(task);
             } else {
               // only displayed element will be updated
               if (task.id && $(task.id).length > 0) {


### PR DESCRIPTION
The bandwith info is fetched from `/proc/net/dev`, output sample as followed:

```
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
  eth0: 1856792543832 7400597418    0    0 456543     0          0   3021599 14530077024236 12495992682    0    0    0     0       0          0
    lo: 2742035815 27100105    0    0    0     0          0         0 2742035815 27100105    0    0    0     0       0          0
```

The origin code's network interface range was hardcoded as `[2, 5)`, so network interfaces' bandwidth info start from line 6 won't be updated correctly.