### PR TITLE
fix: make use of sshd_config.d and sysctl.d

### DIFF
--- a/packages/system/auxiliary/install-BBR.sh
+++ b/packages/system/auxiliary/install-BBR.sh
@@ -172,11 +172,11 @@ function _main() {
 			update-grub >/dev/null 2>&1
 		fi
 		_info "pre-Loading TCP BBR ..."
-		[ ! -f /etc/sysctl.conf ] && touch /etc/sysctl.conf
-		sed -i '/net.core.default_qdisc.*/d' /etc/sysctl.conf
-		sed -i '/net.ipv4.tcp_congestion_control.*/d' /etc/sysctl.conf
-		echo "net.core.default_qdisc=fq" >>/etc/sysctl.conf
-		echo "net.ipv4.tcp_congestion_control=bbr" >>/etc/sysctl.conf
+		[ ! -f /etc/sysctl.d/90-quickbox.conf ] && touch /etc/sysctl.d/90-quickbox.conf
+		sed -i '/net.core.default_qdisc.*/d' /etc/sysctl.d/90-quickbox.conf
+		sed -i '/net.ipv4.tcp_congestion_control.*/d' /etc/sysctl.d/90-quickbox.conf
+		echo "net.core.default_qdisc=fq" >>/etc/sysctl.d/90-quickbox.conf
+		echo "net.ipv4.tcp_congestion_control=bbr" >>/etc/sysctl.d/90-quickbox.conf
 	fi
 	if [[ $replacekernel == 1 ]]; then
 		_warning "The system requires a reboot!"

--- a/setup.sh
+++ b/setup.sh
@@ -335,10 +335,8 @@ function _askchport() {
 }
 
 function _changeport() {
-	if [[ -e /etc/ssh/sshd_config ]]; then
-		sed -i "s/#*Port\s[0-9]*/Port $chport/g" /etc/ssh/sshd_config
-		service ssh restart >>"${OUTTO}" 2>&1
-	fi
+	echo "Port $chport" >>/etc/ssh/sshd_config.d/10-quickbox.conf
+	service ssh restart >>"${OUTTO}" 2>&1
 }
 
 function _askusrname() {


### PR DESCRIPTION
Keep the `sshd_config` file itself unmodified, to avoid prompts for user confirmation during OpenSSH upgrades.

The `Include /etc/ssh/sshd_config.d/*.conf` line has been in the default `sshd_config` file since Debian 11 and Ubuntu 20.04.

I don't think it's necessary to check for existing *.conf files or `sshd -T` here, because typically users would run this script on a freshly installed OS, and the worst scenario would just be that `sshd` listening to port(s) other than the one designated here (e.g. 4747), of which the user should be aware.

----------------------------------------

Since Debian 13 (trixie), `/etc/sysctl.conf` is no longer loaded by `systemd-sysctl`, so we should instead put the BBR configurations under `/etc/sysctl.d/` now.

I have checked that `/etc/sysctl.d/*.conf` is supported by default since at least Debian 11 and Ubuntu 20.04.