### PR TITLE
fix: do not change net.core.default_qdisc when installing BBR

### DIFF
--- a/packages/system/auxiliary/install-BBR.sh
+++ b/packages/system/auxiliary/install-BBR.sh
@@ -173,16 +173,14 @@ function _main() {
 		fi
 		_info "pre-Loading TCP BBR ..."
 		[ ! -f /etc/sysctl.d/90-quickbox.conf ] && touch /etc/sysctl.d/90-quickbox.conf
-		sed -i '/net.core.default_qdisc.*/d' /etc/sysctl.d/90-quickbox.conf
 		sed -i '/net.ipv4.tcp_congestion_control.*/d' /etc/sysctl.d/90-quickbox.conf
-		echo "net.core.default_qdisc=fq" >>/etc/sysctl.d/90-quickbox.conf
 		echo "net.ipv4.tcp_congestion_control=bbr" >>/etc/sysctl.d/90-quickbox.conf
 	fi
 	if [[ $replacekernel == 1 ]]; then
 		_warning "The system requires a reboot!"
 		_success "${APP_TITLE} installation finished."
 	else
-		_execute "sysctl -p"
+		_execute "sysctl --system"
 		_success "${APP_TITLE} started."
 	fi
 }


### PR DESCRIPTION
Setting `net.core.default_qdisc=fq` when enabling BBR, although extremely popular over the years, has long been unnecessary since Linux kernel 4.20, according to: https://groups.google.com/g/bbr-dev/c/4jL4ropdOV8

Furthermore, it is better to just use `net.core.default_qdisc=fq_codel`, which is now the default in all major Linux distros (Debian was the last one to adopt, since bullseye(11)), and `fq` only performs better in very specific circumstances, according to Dave Täht, co-founder of Bufferbloat. See comments in systemd/systemd#9725 as well as https://blog.cerowrt.org/post/state_of_fq_codel/

This commit also fixes a leftover issue of the previous commit: `sysctl -p` no longer works in Debian 13 (it wouldn't find `/etc/sysctl.conf`) at least for now, and we should probably use `sysctl --system` anyway as it reads values from all system directories.