### PR TITLE
fix: use "http2" directive in nginx conf

### DIFF
--- a/packages/package/install/installpackage-h5ai
+++ b/packages/package/install/installpackage-h5ai
@@ -225,8 +225,9 @@ EOF
         if [[ ${lecert} == 0 ]]; then
         cat >/etc/nginx/sites-enabled/h5ai.conf <<EOF
 server {
-    listen              443 ssl http2;
-    listen              [::]:443 ssl http2;
+    listen              443 ssl;
+    listen              [::]:443 ssl;
+    http2               on;
     server_name         ${domain};
     root                ${target};
 
@@ -323,8 +324,9 @@ EOF
             sock='php7.4-fpm'
             cat >/etc/nginx/sites-enabled/h5ai.conf <<EOF
 server {
-    listen              443 ssl http2;
-    listen              [::]:443 ssl http2;
+    listen              443 ssl;
+    listen              [::]:443 ssl;
+    http2               on;
     server_name         ${domain};
     root                ${target};
 
@@ -423,8 +425,9 @@ EOF
 
             cat >/etc/nginx/sites-enabled/h5ai.conf <<EOF
 server {
-    listen              443 ssl http2;
-    listen              [::]:443 ssl http2;
+    listen              443 ssl;
+    listen              [::]:443 ssl;
+    http2               on;
     server_name         ${domain};
     root                ${target};
 

--- a/packages/package/install/installpackage-lecert
+++ b/packages/package/install/installpackage-lecert
@@ -214,8 +214,9 @@ server {
 
 # SSL configuration
 server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
     server_name ${domain};
     ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
     ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
@@ -274,8 +275,9 @@ server {
 
 # SSL configuration
 server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
     server_name ${domain};
     ssl_certificate /etc/nginx/ssl/${domain}/${domain}-ssl.pem;
     ssl_certificate_key /etc/nginx/ssl/${domain}/${domain}-key.pem;

--- a/packages/package/remove/removepackage-lecert
+++ b/packages/package/remove/removepackage-lecert
@@ -162,8 +162,9 @@ server {
 
 # SSL configuration
 server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
     server_name _;
     ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
     ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;

--- a/setup/templates/nginx/default.template
+++ b/setup/templates/nginx/default.template
@@ -17,8 +17,9 @@ server {
 
 # SSL configuration
 server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
     server_name _;
     ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
     ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;


### PR DESCRIPTION
...instead of the deprecated "listen ... http2" directive.

The deprecation was introduced in nginx 1.25.1.